### PR TITLE
fix: disable speckle filter in depth map processing

### DIFF
--- a/src/vision_processing/depthai_pipeline.py
+++ b/src/vision_processing/depthai_pipeline.py
@@ -73,7 +73,7 @@ class DepthAIPipeline:
 
         # Optional: Adjust post-processing filters for the depth map.
         config = depth.initialConfig.get()
-        config.postProcessing.speckleFilter.enable = True
+        config.postProcessing.speckleFilter.enable = False
         config.postProcessing.speckleFilter.speckleRange = 25
         config.postProcessing.temporalFilter.enable = True
         config.postProcessing.spatialFilter.enable = True


### PR DESCRIPTION
Disable the speckle filter in the depth map post-processing configuration by setting `speckleFilter.enable` to False.